### PR TITLE
force ipv4 dns resolve if we're using ipv4 connections

### DIFF
--- a/mrblib/simplehttp.rb
+++ b/mrblib/simplehttp.rb
@@ -34,7 +34,7 @@ class SimpleHttp
       # nothing
     elsif @use_uv
       ip = ""
-      UV::getaddrinfo(address, "http") do |x, info|
+      UV::getaddrinfo(address, "http", ai_family: :ipv4) do |x, info|
         if info 
           ip = info.addr
         end


### PR DESCRIPTION
Depending on your network settings, dns can resolve ipv6 back instead of ipv4. This will break `UV::ip4_addr` since it expects ipv4. This patch forces ipv4 dns resolution.