### PR TITLE
fix unfound mrbgem mruby-sprintf

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -4,6 +4,6 @@ MRuby::Gem::Specification.new('mruby-simplehttp') do |spec|
   spec.version = '0.0.1'
   # need mruby-socket or mruby-uv
   spec.add_dependency('mruby-socket')
-  spec.add_dependency('mruby-sprintf')
+  spec.add_dependency('mruby-sprintf', :core => 'mruby-sprintf')
   #spec.add_dependency('mruby-polarssl')
 end


### PR DESCRIPTION
When adding mruby-httprequest to a mruby-cli app, it can't find the mruby-sprintf

```
mgem not found: mruby-sprintf
```

explicitly saying it comes from the core, fix it.